### PR TITLE
Downgrade isolated-bus correction log from error to warn

### DIFF
--- a/src/pm_io/psse.jl
+++ b/src/pm_io/psse.jl
@@ -2359,7 +2359,7 @@ function _pti_to_powermodels!(
                             "PSEE reference bus $(b_number) that is topologically isolated from the system. Indicates an error in the data.",
                         )
                     end
-                    @error "PSEE data file contains a topologically isolated bus $(b_number) that is disconnected from the system and set to bus_type = $(b_type) instead of 4. Likely indicates an error in the data."
+                    @warn "PSEE data file contains a topologically isolated bus $(b_number) that is disconnected from the system and set to bus_type = $(b_type) instead of 4. Likely indicates an error in the data. Correcting to bus_type = 4 (out of service)."
                     pm_data["bus"][b]["bus_type"] = 4
                     pm_data["bus"][b]["bus_status"] = false
                 end


### PR DESCRIPTION
This occurs commonly in industry cases (e.g. a stranded bus record that is effectively removed (all connecting branches disconnected, loads/generators set to unavailable, etc.) but left in the file. I think a warn is more appropriate in this case. This fixes the PSB test as well which assumes no errors logged.

